### PR TITLE
[Doppins] Upgrade dependency Django to ==1.9.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.9.8
+Django==1.10
 django-tastypie==0.12.1
 elasticsearch==1.2.0
 python-dateutil==2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.10
+Django==1.10.1
 django-tastypie==0.12.1
 elasticsearch==1.2.0
 python-dateutil==2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.7.1
+Django==1.9.8
 django-tastypie==0.12.1
 elasticsearch==1.2.0
 python-dateutil==2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.10.1
+Django==1.10.2
 django-tastypie==0.12.1
 elasticsearch==1.2.0
 python-dateutil==2.2


### PR DESCRIPTION
Hi!

A new version was just released of `Django`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded Django from `==1.7.1` to `==1.9.8`
